### PR TITLE
docs: fix macOS spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OpenRoute.ai is a web application designed to provide optimized itineraries and 
    ```sh
    python -m venv venv
    .\venv\Scripts\activate  # For Windows
-   source venv/bin/activate  # For MacOS/Linux
+   source venv/bin/activate  # For macOS/Linux
    ```
 
 3. Install the required packages:


### PR DESCRIPTION
## Summary
- correct the macOS spelling in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68503f86b754832a8fce4febf9bc99fd